### PR TITLE
Support for SPA routing frameworks

### DIFF
--- a/oidc-client.js
+++ b/oidc-client.js
@@ -44,6 +44,9 @@ function parseOidcResult(queryString) {
 
     var idx = queryString.lastIndexOf("#");
     if (idx >= 0) {
+        var lastQuestionMarkIndex = queryString.lastIndexOf("?");
+        idx = Math.max(idx, lastQuestionMarkIndex);
+        
         queryString = queryString.substr(idx + 1);
     }
 


### PR DESCRIPTION
The method `parseOidcResult` currently parses the OIDC result by splitting a given query string or the value from `location.hash` at the hash sign (#), taking the last part of it, and then start splitting the key-value-pairs by the ampersand sign (&).
Routing frameworks for Single-Page Applications, such as _ui-router_, also rely on the fragment identifier for in-app routing. Routes are usually start with a slash, followed by the route’s name and optionally further values. The routes have to be registered when the app launches. However, it’s possible to append dynamic values by using the question mark sign (?). The string that follows this sign acts as a kind of query string for the route.
Following the logic from above, parsing `#/tokenReceived?amr=password&at_hash=x` currently leads to two parameters: `/tokenReceived?amr` with a value of `password` (which is wrong) and `at_hash` with a value of `x` (which is okay).
Therefore, if the fragment identifier contains a question mark sign, parsing should start there in order to support SPA routing frameworks. As the values are URL encoded, this should not lead to any problems.