### PR TITLE
Check for IE9 before processing response

### DIFF
--- a/lib/defaultHttpRequest.js
+++ b/lib/defaultHttpRequest.js
@@ -45,12 +45,18 @@ function DefaultHttpRequest() {
                 xhr.onload = function () {
                     try {
                         if (xhr.status === 200) {
-                            var response = xhr.response;
-                            if (typeof response === "string") {
-                                response = JSON.parse(response);
+                                var response = "";
+                                // To support IE9 get the response from xhr.responseText not xhr.response
+                                if (window.XDomainRequest) {
+                                    response = xhr.responseText;
+                                } else {
+                                    response = xhr.response;
+                                }
+                                if (typeof response === "string") {
+                                    response = JSON.parse(response);
+                                }
+                                resolve(response);
                             }
-                            resolve(response);
-                        }
                         else {
                             reject(Error(xhr.statusText + "(" + xhr.status + ")"));
                         }


### PR DESCRIPTION
IE10 and up support xhr.response, but older versions use
xhr.responseText